### PR TITLE
Added GltfMain property and tests for it

### DIFF
--- a/Svrf.Tests.Integration/Models/PropertiesTest.cs
+++ b/Svrf.Tests.Integration/Models/PropertiesTest.cs
@@ -113,7 +113,9 @@ namespace Svrf.Tests.Integration.Models
 
             CheckString(files.Glb);
             CheckString(files.GlbDraco);
+
             Assert.IsNotEmpty(files.Gltf);
+            CheckString(files.GltfMain);
         }
 
         private void VerifyBasicFields(MediaModel media)

--- a/Svrf.Tests.Unit/Models/HttpRequestParamsTest.cs
+++ b/Svrf.Tests.Unit/Models/HttpRequestParamsTest.cs
@@ -2,7 +2,7 @@
 using NUnit.Framework;
 using Svrf.Models.Http;
 
-namespace Svrf.Tests.Unit.Models.Http
+namespace Svrf.Tests.Unit.Models
 {
     [TestFixture]
     public class HttpRequestParamsTest

--- a/Svrf.Tests.Unit/Models/MediaFilesTest.cs
+++ b/Svrf.Tests.Unit/Models/MediaFilesTest.cs
@@ -51,5 +51,18 @@ namespace Svrf.Tests.Unit.Models
 
             Assert.AreEqual(GltfUrl, files.GltfMain);
         }
+
+        [Test]
+        public void GltfMain_UpperCaseValues_ReturnsMainFile()
+        {
+            var gltfUrl = GltfUrl.Replace("gltf", "GLTF");
+
+            var gltfFiles = new Dictionary<string, string>(_nonGltfFiles);
+            gltfFiles.Add("DogeBlender2.GLTF", gltfUrl);
+
+            var files = new MediaFiles { Gltf = gltfFiles };
+
+            Assert.AreEqual(gltfUrl, files.GltfMain);
+        }
     }
 }

--- a/Svrf.Tests.Unit/Models/MediaFilesTest.cs
+++ b/Svrf.Tests.Unit/Models/MediaFilesTest.cs
@@ -7,6 +7,7 @@ namespace Svrf.Tests.Unit.Models
     [TestFixture]
     public class MediaFilesTest
     {
+        private const string GltfFileName = "DogeBlender2.gltf";
         private const string GltfUrl = "https://www.svrf.com/storage/svrf-models/676167/gltf/DogeBlender2.gltf";
 
         private readonly Dictionary<string, string> _nonGltfFiles = new Dictionary<string, string>
@@ -45,7 +46,7 @@ namespace Svrf.Tests.Unit.Models
         public void GltfMain_HasGltfFiles_ReturnsMainFile()
         {
             var gltfFiles = new Dictionary<string, string>(_nonGltfFiles);
-            gltfFiles.Add("DogeBlender2.gltf", GltfUrl);
+            gltfFiles.Add(GltfFileName, GltfUrl);
 
             var files = new MediaFiles {Gltf = gltfFiles};
 
@@ -55,14 +56,19 @@ namespace Svrf.Tests.Unit.Models
         [Test]
         public void GltfMain_UpperCaseValues_ReturnsMainFile()
         {
-            var gltfUrl = GltfUrl.Replace("gltf", "GLTF");
+            var gltfUrl = GltfExtensionToUpper(GltfUrl);
 
             var gltfFiles = new Dictionary<string, string>(_nonGltfFiles);
-            gltfFiles.Add("DogeBlender2.GLTF", gltfUrl);
+            gltfFiles.Add(GltfExtensionToUpper(GltfFileName), gltfUrl);
 
             var files = new MediaFiles { Gltf = gltfFiles };
 
             Assert.AreEqual(gltfUrl, files.GltfMain);
+        }
+
+        private string GltfExtensionToUpper(string s)
+        {
+            return s.Replace("gltf", "GLTF");
         }
     }
 }

--- a/Svrf.Tests.Unit/Models/MediaFilesTest.cs
+++ b/Svrf.Tests.Unit/Models/MediaFilesTest.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using Svrf.Models.Media;
+
+namespace Svrf.Tests.Unit.Models
+{
+    [TestFixture]
+    public class MediaFilesTest
+    {
+        private const string GltfUrl = "https://www.svrf.com/storage/svrf-models/676167/gltf/DogeBlender2.gltf";
+
+        private readonly Dictionary<string, string> _nonGltfFiles = new Dictionary<string, string>
+        {
+            {"brow.jpg", "https://www.svrf.com/storage/svrf-models/676167/gltf/brow.jpg"},
+            {"buffer.bin", "https://www.svrf.com/storage/svrf-models/676167/gltf/buffer.bin"},
+            {"eye.jpg", "https://www.svrf.com/storage/svrf-models/676167/gltf/eye.jpg"},
+            {"eyelids.jpg", "https://www.svrf.com/storage/svrf-models/676167/gltf/eyelids.jpg"},
+            { "face.jpg", "https://www.svrf.com/storage/svrf-models/676167/gltf/face.jpg"},
+        };
+
+        [Test]
+        public void GltfMain_NoGltfFiles_IsNull()
+        {
+            var files = new MediaFiles();
+            Assert.IsNull(files.GltfMain);
+        }
+
+        [Test]
+        public void GltfMain_EmptyGltfDictionary_IsNull()
+        {
+            var files = new MediaFiles {Gltf = new Dictionary<string, string>()};
+            Assert.IsNull(files.GltfMain);
+        }
+
+        [Test]
+        public void GltfMain_NoMainFile_IsNull()
+        {
+            var gltfFiles = new Dictionary<string, string>(_nonGltfFiles);
+            var files = new MediaFiles { Gltf = gltfFiles };
+
+            Assert.IsNull(files.GltfMain);
+        }
+
+        [Test]
+        public void GltfMain_HasGltfFiles_ReturnsMainFile()
+        {
+            var gltfFiles = new Dictionary<string, string>(_nonGltfFiles);
+            gltfFiles.Add("DogeBlender2.gltf", GltfUrl);
+
+            var files = new MediaFiles {Gltf = gltfFiles};
+
+            Assert.AreEqual(GltfUrl, files.GltfMain);
+        }
+    }
+}

--- a/Svrf.Tests.Unit/Svrf.Tests.Unit.csproj
+++ b/Svrf.Tests.Unit/Svrf.Tests.Unit.csproj
@@ -72,7 +72,8 @@
     <Compile Include="Mocks\MockEnum.cs" />
     <Compile Include="Mocks\RequestMocks.cs" />
     <Compile Include="Mocks\ResponseMocks.cs" />
-    <Compile Include="Models\Http\HttpRequestParamsTest.cs" />
+    <Compile Include="Models\HttpRequestParamsTest.cs" />
+    <Compile Include="Models\MediaFilesTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\QueryServiceTest.cs" />
     <Compile Include="Services\TokenServiceTest.cs" />

--- a/Svrf/Models/Media/MediaFiles.cs
+++ b/Svrf/Models/Media/MediaFiles.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace Svrf.Models.Media
@@ -8,11 +9,20 @@ namespace Svrf.Models.Media
         public MediaImages Images { get; set; }
         public MediaVideos Videos { get; set; }
         public MediaStereo Stereo { get; set; }
-        public Dictionary<string, string> Gltf { get; set; }
-        public string Glb { get; set; }
 
         [JsonProperty("glb-draco")]
         public string GlbDraco { get; set; }
+        public string Glb { get; set; }
+
+        public Dictionary<string, string> Gltf { get; set; }
+        public string GltfMain
+        {
+            get
+            {
+                var fileName = Gltf?.Keys.FirstOrDefault(k => k.EndsWith(".gltf"));
+                return fileName == null ? null : Gltf[fileName];
+            }
+        }
 
         public override bool Equals(object obj)
         {

--- a/Svrf/Models/Media/MediaFiles.cs
+++ b/Svrf/Models/Media/MediaFiles.cs
@@ -19,7 +19,7 @@ namespace Svrf.Models.Media
         {
             get
             {
-                var fileName = Gltf?.Keys.FirstOrDefault(k => k.EndsWith(".gltf"));
+                var fileName = Gltf?.Keys.FirstOrDefault(k => k.ToLower().EndsWith(".gltf"));
                 return fileName == null ? null : Gltf[fileName];
             }
         }


### PR DESCRIPTION
Added `GltfMain` property to the `MediaFiles` class. It looks for a key that ends with `.gltf`. Since it uses keys for searching, not values, it'll work for URLs with query params as well.

Closes #4